### PR TITLE
Fix uninitialized variables in DocumentAI parser

### DIFF
--- a/audico_product_manager/docai_parser.py
+++ b/audico_product_manager/docai_parser.py
@@ -324,6 +324,11 @@ TEXT TO PROCESS:
 
     def _extract_products_from_document(self, document: documentai.Document) -> List[ProductData]:
         products = []
+        # Temporary variables to collect entity information
+        name = None
+        model = None
+        price = None
+        manufacturer = None
         try:
             entities = document.entities
             for entity in entities:
@@ -344,11 +349,12 @@ TEXT TO PROCESS:
                     product = ProductData(
                         name=name,
                         model=model,
-                        price=self._price_to_rands(price),
+                        price=self._price_to_rands(price) if price else None,
                         manufacturer=manufacturer,
                         online_store_name=self._make_online_store_name(name, model, manufacturer)
                     )
                     products.append(product)
+                    name = model = price = manufacturer = None
         except Exception as e:
             self.logger.error(f"Error extracting products from document: {str(e)}")
         return products


### PR DESCRIPTION
## Summary
- prevent `UnboundLocalError` in `docai_parser` when Document AI entities are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68432099a0d083228e30a3b16420ea84