### PR TITLE
Fix numbering in test comment

### DIFF
--- a/audico_product_manager/test_live_opencart_connection.py
+++ b/audico_product_manager/test_live_opencart_connection.py
@@ -63,7 +63,7 @@ def test_opencart_connection():
             print("✗ No AVR products found")
         
         # Test searching for Denon products
-        print("\n2b. Testing search for 'Denon' products...")
+        print("\n2c. Testing search for 'Denon' products...")
         denon_products = client.search_products("Denon")
         if denon_products:
             print(f"✓ Found {len(denon_products)} Denon products")


### PR DESCRIPTION
## Summary
- fix numbering in `test_live_opencart_connection.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6843247a74b48322bc9d2b1e39369405