### PR TITLE
Fix docstring for product pagination

### DIFF
--- a/audico_product_manager/opencart_client.py
+++ b/audico_product_manager/opencart_client.py
@@ -301,14 +301,13 @@ class OpenCartAPIClient:
         return self._make_request('POST', '/categories', data=category_data)
     
     def get_products(self, search_term: str = "", limit: int = 100, page: int = 1) -> Optional[List[Dict]]:
-        """
-        Retrieve products from OpenCart using search.
-        
+        """Retrieve products from OpenCart using search.
+
         Args:
             search_term: Search term for products (empty string returns all)
-            limit: Number of products to return
-            page: Page number (for compatibility, not used in current implementation)
-            
+            limit: Unused. Reserved for future support of result limiting.
+            page: Unused. Placeholder for future pagination support.
+
         Returns:
             List[Dict]: List of products or None if request failed
         """


### PR DESCRIPTION
## Summary
- note that pagination parameters are currently unused in `get_products`

## Testing
- `pip install -r audico_product_manager/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6843248e97c48322a3595b4ef21e23e2