### PR TITLE
Refactor OpenAI connection test for pytest

### DIFF
--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -157,7 +157,7 @@ npm run dev
 ### 2. Core System Testing
 ```bash
 cd audico_product_manager
-python -m pytest tests/  # If tests are available
+pytest  # runs all available tests
 python orchestrator.py --dry-run  # Safe testing mode
 ```
 

--- a/test_openai.py
+++ b/test_openai.py
@@ -2,30 +2,20 @@ import os
 from dotenv import load_dotenv
 import openai
 
-# Load environment variables
+
 load_dotenv()
 
-def test_openai_connection():
-    api_key = os.getenv('OPENAI_API_KEY')
 
-    print(f"🔑 API Key found: {api_key[:10]}...{api_key[-4:] if api_key else 'None'}")
+def test_openai_connection() -> None:
+    """Verify that the OpenAI API can be reached with the provided key."""
+    api_key = os.getenv("OPENAI_API_KEY")
 
-    if not api_key or api_key == 'your_openai_api_key_here':
-        print("❌ Invalid API key in .env file")
-        return False
+    assert api_key and api_key != "your_openai_api_key_here", "Invalid API key in .env file"
 
-    try:
-        client = openai.OpenAI(api_key=api_key)
-        response = client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": "Hello"}],
-            max_tokens=5
-        )
-        print("✅ OpenAI API connection successful!")
-        return True
-    except Exception as e:
-        print(f"❌ OpenAI API error: {e}")
-        return False
-
-if __name__ == "__main__":
-    test_openai_connection()
+    client = openai.OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=5,
+    )
+    assert response is not None


### PR DESCRIPTION
## Summary
- convert the OpenAI check to a pytest test that uses assertions
- document running tests with `pytest`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opencart_client')*

------
https://chatgpt.com/codex/tasks/task_e_68432498210883228c92594206360287