### PR TITLE
Improve online store naming

### DIFF
--- a/docai_parser.py
+++ b/docai_parser.py
@@ -1,0 +1,1 @@
+from audico_product_manager.docai_parser import *

--- a/opencart_client.py
+++ b/opencart_client.py
@@ -1,0 +1,1 @@
+from audico_product_manager.opencart_client import *

--- a/product_comparison.py
+++ b/product_comparison.py
@@ -1,0 +1,1 @@
+from audico_product_manager.product_comparison import *


### PR DESCRIPTION
## Summary
- add root-level wrappers for easier test imports
- use OpenAI to generate store-friendly names in parser
- fall back to existing cleanup logic when AI unavailable

## Testing
- `pytest -q` *(fails: Invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_684328b5497c8322ad5119271441b4fd